### PR TITLE
Disable timing-out when a debugging session is in progress

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     rev: 3.7.7
     hooks:
       - id: flake8
-        language_version: python2
+        language_version: python3
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v1.4.0
     hooks:

--- a/README.rst
+++ b/README.rst
@@ -16,21 +16,27 @@ pytest-timeout
 .. |python| image:: https://img.shields.io/pypi/pyversions/pytest-timeout.svg
   :target: https://pypi.python.org/pypi/pytest-timeout/
 
-This is a plugin which will terminate tests after a certain timeout.
-When doing so it will show a stack dump of all threads running at the
-time.  This is useful when running tests under a continuous
-integration server or simply if you don't know why the test suite
-hangs.
+This is a plugin which will terminate tests after a certain timeout,
+assuming the test session isn't being debugged. When aborting a test
+it will show a stack dump of all threads running at the time.
+This is useful when running tests under a continuous
+integration server or simply if you don't know why the test suite hangs.
 
-Note that while by default on POSIX systems py.test will continue to
-execute the tests after a test has timed, out this is not always
-possible.  Often the only sure way to interrupt a hanging test is by
-terminating the entire process.  As this is a hard termination
-(``os._exit()``) it will result in no teardown, JUnit XML output etc.
-But the plugin will ensure you will have the debugging output on
-stderr nevertheless, which is the most important part at this stage.
-See below for detailed information on the timeout methods and their
-side-effects.
+.. note::
+    The way this plugin detects whether or not a debugging session is active
+    is by checking if `pydevd.py` is present in frames OR if `pytest` drops
+    you into PBD.
+
+.. note::
+    While by default on POSIX systems py.test will continue to
+    execute the tests after a test has timed, out this is not always
+    possible.  Often the only sure way to interrupt a hanging test is by
+    terminating the entire process.  As this is a hard termination
+    (``os._exit()``) it will result in no teardown, JUnit XML output etc.
+    But the plugin will ensure you will have the debugging output on
+    stderr nevertheless, which is the most important part at this stage.
+    See below for detailed information on the timeout methods and their
+    side-effects.
 
 The pytest-timeout plugin has been tested on python 2.7 or higher,
 including 3.X, pypy and pypy3.  See tox.ini for currently tested
@@ -190,6 +196,11 @@ might result in clearer output.
 
 Changelog
 =========
+
+1.3.5
+-----
+
+- Better detection of when we are debugging, thanks Mattwmaster58
 
 1.3.4
 -----

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,9 @@ integration server or simply if you don't know why the test suite hangs.
 
 .. note::
     The way this plugin detects whether or not a debugging session is active
-    is by checking if ``pydevd.py`` is present in any of the stack frames OR
-    if pytest itself drops you into a pbd session.
+    is by checking if a trace function is set and if one is, it check to see
+    if the module it belongs to is present in a set of known debugging
+    frameworks modules OR if pytest itself drops you into a pbd session.
 
 .. note::
     While by default on POSIX systems pytest will continue to

--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ might result in clearer output.
 Changelog
 =========
 
-1.3.5
+1.4.0
 -----
 
 - Better detection of when we are debugging, thanks Mattwmaster58

--- a/README.rst
+++ b/README.rst
@@ -24,12 +24,12 @@ integration server or simply if you don't know why the test suite hangs.
 
 .. note::
     The way this plugin detects whether or not a debugging session is active
-    is by checking if `pydevd.py` is present in frames OR if `pytest` drops
-    you into PBD.
+    is by checking if `pydevd.py` is present in any of the stack frames OR
+    if pytest itself drops you into a pbd session.
 
 .. note::
-    While by default on POSIX systems py.test will continue to
-    execute the tests after a test has timed, out this is not always
+    While by default on POSIX systems pytest will continue to
+    execute the tests after a test has timed out this is not always
     possible.  Often the only sure way to interrupt a hanging test is by
     terminating the entire process.  As this is a hard termination
     (``os._exit()``) it will result in no teardown, JUnit XML output etc.
@@ -53,7 +53,7 @@ Install is as simple as e.g.::
 Now you can run tests using a timeout, in seconds, after which they
 will be terminated::
 
-   py.test --timeout=300
+   pytest --timeout=300
 
 Alternatively you can mark individual tests as having a timeout::
 
@@ -66,7 +66,7 @@ valid timeout for the plugin to interrupt long-running tests.  A
 timeout is always specified as a number of seconds, and can be
 defined in a number of ways, from low to high priority:
 
-1. You can set a global timeout in the `py.test configuration file`__
+1. You can set a global timeout in the `pytest configuration file`__
    using the ``timeout`` option.  E.g.::
 
       [pytest]
@@ -117,7 +117,7 @@ this timer thread is cancelled and the test run continues.
 
 The downsides of this method are that there is a relatively large
 overhead for running each test and that test runs are not completed.
-This means that other py.test features, like e.g. JUnit XML output or
+This means that other pytest features, like e.g. JUnit XML output or
 fixture teardown, will not function normally.  The second issue might
 be alleviated by using the ``--boxed`` option of the pytest-xdist_
 plugin.
@@ -137,7 +137,7 @@ starts and cancels it when it finishes.  If the alarm expires during
 the test the signal handler will dump the stack of any other threads
 running to stderr and use ``pytest.fail()`` to interrupt the test.
 
-The benefit of this method is that the py.test process is not
+The benefit of this method is that the pytest process is not
 terminated and the test run can complete normally.
 
 The main issue to look out for with this method is that it may
@@ -149,7 +149,7 @@ Specifying the Timeout Method
 -----------------------------
 
 The timeout method can be specified by using the ``timeout_method``
-option in the `py.test configuration file`__, the ``--timeout_method``
+option in the `pytest configuration file`__, the ``--timeout_method``
 command line parameter or the ``timeout`` marker_.  Simply set their
 value to the string ``thread`` or ``signal`` to override the default
 method.  On a marker this is done using the ``method`` keyword::
@@ -264,9 +264,9 @@ Changelog
 -----
 
 * Bump version to 1.0 to commit to semantic versioning.
-* Fix issue #12: Now compatible with py.test 2.8, thanks Holger Krekel.
+* Fix issue #12: Now compatible with pytest 2.8, thanks Holger Krekel.
 * No longer test with pexpect on py26 as it is no longer supported
-* Require py.test 2.8 and use new hookimpl decorator
+* Require pytest 2.8 and use new hookimpl decorator
 
 0.5
 ---
@@ -284,7 +284,7 @@ Changelog
 * Support timeouts happening in (session scoped) finalizers.
 
 * Change command line option --timeout_method into --timeout-method
-  for consistency with py.test
+  for consistency with pytest
 
 0.3
 ---

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ integration server or simply if you don't know why the test suite hangs.
 
 .. note::
     The way this plugin detects whether or not a debugging session is active
-    is by checking if `pydevd.py` is present in any of the stack frames OR
+    is by checking if ``pydevd.py`` is present in any of the stack frames OR
     if pytest itself drops you into a pbd session.
 
 .. note::

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -38,7 +38,7 @@ function body, ignoring the time it takes when evaluating any fixtures
 used in the test.
 """.strip()
 
-KNOWN_DEBUGGING_MODULES = {"pydevd"}
+KNOWN_DEBUGGING_MODULES = {"pydevd", "ipdb"}
 Settings = namedtuple("Settings", ["timeout", "method", "func_only"])
 
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -140,7 +140,11 @@ SUPPRESS_TIMEOUT = False
 def timeout_setup(item):
     """Setup up a timeout trigger and handler"""
     params = get_params(item)
-    if params.timeout is None or params.timeout <= 0:
+
+    def is_debugging():
+        return any(True for frame in inspect.stack() if frame[1].endswith('pydevd.py'))
+
+    if params.timeout is None or params.timeout <= 0 or is_debugging():
         return
     if params.method == "signal":
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -6,6 +6,7 @@ useful when running tests on a continuous integration server.
 If the platform supports SIGALRM this is used to raise an exception in
 the test, otherwise os._exit(1) is used.
 """
+import inspect
 import os
 import signal
 import sys

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -6,7 +6,6 @@ useful when running tests on a continuous integration server.
 If the platform supports SIGALRM this is used to raise an exception in
 the test, otherwise os._exit(1) is used.
 """
-import inspect
 import os
 import signal
 import sys
@@ -144,9 +143,16 @@ def is_debugging():
         2. Check is SUPPRESS_TIMEOUT is set to True
     """
     global SUPPRESS_TIMEOUT
-    return SUPPRESS_TIMEOUT or any(
-        True for frame in inspect.stack() if frame[1].endswith("pydevd.py")
-    )
+    known_debugging_modules = {"pydevd"}
+    if SUPPRESS_TIMEOUT:
+        return True
+    else:
+        trace_func = sys.gettrace()
+        if trace_func:
+            for known_debugging_module in known_debugging_modules:
+                if known_debugging_module in trace_func.__module__:
+                    return True
+    return False
 
 
 SUPPRESS_TIMEOUT = False

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -138,12 +138,14 @@ def pytest_enter_pdb():
 
 
 def is_debugging():
-    """
-    Detects if a debugging session is in progress by checking if either of
-     the following conditions is true:
-        1. Examines the trace function to see if the module it
-     originates from is in KNOWN_DEBUGGING_MODULES
-        2. Check is SUPPRESS_TIMEOUT is set to True
+    """Detects if a debugging session is in progress.
+
+     This is done by checking if either of the following conditions is
+     true:
+
+     1. Examines the trace function to see if the module it originates
+        from is in KNOWN_DEBUGGING_MODULES
+     2. Check is SUPPRESS_TIMEOUT is set to True
     """
     global SUPPRESS_TIMEOUT, KNOWN_DEBUGGING_MODULES
     if SUPPRESS_TIMEOUT:

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -139,11 +139,13 @@ def is_debugging():
     """
     Detects if a debugging session is in progress by checking if either of two conditions is true. 
         1. examining the stack frames to see if pydevd.py — 
-            a debugging framework used by VSCode, PyCharm, and others — is present.
+     a debugging framework used by VSCode, PyCharm, and others — is present.
         2. Check is SUPPRESS_TIMEOUT is set to True
     """
     global SUPPRESS_TIMEOUT
-    return SUPPRESS_TIMEOUT or any(True for frame in inspect.stack() if frame[1].endswith("pydevd.py"))
+    return SUPPRESS_TIMEOUT or any(
+        True for frame in inspect.stack() if frame[1].endswith("pydevd.py")
+    )
 
 
 SUPPRESS_TIMEOUT = False

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -38,7 +38,8 @@ function body, ignoring the time it takes when evaluating any fixtures
 used in the test.
 """.strip()
 
-KNOWN_DEBUGGING_MODULES = {"pydevd", "ipdb"}
+# bdb convers pdb, ipdb, and possible others
+KNOWN_DEBUGGING_MODULES = {"pydevd", "bdb"}
 Settings = namedtuple("Settings", ["timeout", "method", "func_only"])
 
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -38,7 +38,8 @@ function body, ignoring the time it takes when evaluating any fixtures
 used in the test.
 """.strip()
 
-# bdb convers pdb, ipdb, and possible others
+# bdb covers pdb, ipdb, and possibly others
+# pydevd covers PyCharm, VSCode, and possibly others
 KNOWN_DEBUGGING_MODULES = {"pydevd", "bdb"}
 Settings = namedtuple("Settings", ["timeout", "method", "func_only"])
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -38,6 +38,7 @@ function body, ignoring the time it takes when evaluating any fixtures
 used in the test.
 """.strip()
 
+KNOWN_DEBUGGING_MODULES = {"pydevd"}
 Settings = namedtuple("Settings", ["timeout", "method", "func_only"])
 
 
@@ -138,19 +139,18 @@ def is_debugging():
     """
     Detects if a debugging session is in progress by checking if either of
      the following conditions is true:
-        1. examining the stack frames to see if pydevd.py —
-     a debugging framework used by VSCode, PyCharm, and others — is present.
+        1. Examines the trace function to see if the module it
+     originates from is in KNOWN_DEBUGGING_MODULES
         2. Check is SUPPRESS_TIMEOUT is set to True
     """
-    global SUPPRESS_TIMEOUT
-    known_debugging_modules = {"pydevd"}
+    global SUPPRESS_TIMEOUT, KNOWN_DEBUGGING_MODULES
     if SUPPRESS_TIMEOUT:
         return True
     else:
         trace_func = sys.gettrace()
         if trace_func:
-            for known_debugging_module in known_debugging_modules:
-                if known_debugging_module in trace_func.__module__:
+            for name in KNOWN_DEBUGGING_MODULES:
+                if name in trace_func.__module__:
                     return True
     return False
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -137,8 +137,9 @@ def pytest_enter_pdb():
 
 def is_debugging():
     """
-    Detects if a debugging session is in progress by checking if either of two conditions is true.
-        1. examining the stack frames to see if pydevd.py — 
+    Detects if a debugging session is in progress by checking if either of
+     the following conditions is true:
+        1. examining the stack frames to see if pydevd.py —
      a debugging framework used by VSCode, PyCharm, and others — is present.
         2. Check is SUPPRESS_TIMEOUT is set to True
     """

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -137,7 +137,7 @@ def pytest_enter_pdb():
 
 def is_debugging():
     """
-    Detects if a debugging session is in progress by checking if either of two conditions is true. 
+    Detects if a debugging session is in progress by checking if either of two conditions is true.
         1. examining the stack frames to see if pydevd.py — 
      a debugging framework used by VSCode, PyCharm, and others — is present.
         2. Check is SUPPRESS_TIMEOUT is set to True

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -162,7 +162,6 @@ SUPPRESS_TIMEOUT = False
 def timeout_setup(item):
     """Setup up a timeout trigger and handler"""
     params = get_params(item)
-
     if params.timeout is None or params.timeout <= 0:
         return
     if params.method == "signal":

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name="pytest-timeout",
     description="py.test plugin to abort hanging tests",
     long_description=long_description,
-    version="1.3.4",
+    version="1.3.5",
     author="Floris Bruynooghe",
     author_email="flub@devork.be",
     url="http://github.com/pytest-dev/pytest-timeout/",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name="pytest-timeout",
     description="py.test plugin to abort hanging tests",
     long_description=long_description,
-    version="1.3.5",
+    version="1.4.0",
     author="Floris Bruynooghe",
     author_email="flub@devork.be",
     url="http://github.com/pytest-dev/pytest-timeout/",

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -414,9 +414,10 @@ def test_suppresses_timeout_when_debugger_is_entered(
         @pytest.mark.timeout(1)
         def test_foo():
             {debugging_module}.{debugging_set_trace}
-    """.format(debugging_module=debugging_module, debugging_set_trace=debugging_set_trace)
+    """.format(
+            debugging_module=debugging_module, debugging_set_trace=debugging_set_trace
+        )
     )
-    # todo: pydevd server @ port 4678
     child = testdir.spawn_pytest(str(p1))
     child.expect("test_foo")
     time.sleep(2)

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -389,7 +389,14 @@ def test_marker_help(testdir):
     "debugging_module,debugging_set_trace",
     [
         ("pdb", "set_trace()"),
-        ("ipdb", "set_trace()"),
+        pytest.param(
+            "ipdb",
+            "set_trace()",
+            marks=pytest.mark.xfail(
+                reason="waiting on https://github.com/pytest-dev/pytest/pull/7207"
+                " to allow proper testing"
+            ),
+        ),
         pytest.param(
             "pydevd",
             "settrace(port=4678)",

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -396,8 +396,14 @@ def test_marker_help(testdir):
 
 
 @have_spawn
-@pytest.mark.parametrize("debugging_module", ("pdb", "ipdb", "pydevd"))
-@pytest.mark.parametrize("debugging_module", ("set_trace", "set_trace", "settrace"))
+@pytest.mark.parametrize(
+    "debugging_module,debugging_set_trace",
+    [
+        ("pdb", "set_trace"),
+        ("ipdb", "set_trace"),
+        ("pydevd", "settrace"),
+    ],  # noqa: E231
+)
 def test_suppresses_timeout_when_debugger_is_entered(
     testdir, debugging_module, debugging_set_trace
 ):

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -2,12 +2,16 @@ import os.path
 import signal
 import time
 
+import pexpect
 import pytest
 
 pytest_plugins = "pytester"
 
 have_sigalrm = pytest.mark.skipif(
     not hasattr(signal, "SIGALRM"), reason="OS does not have SIGALRM"
+)
+have_spawn = pytest.mark.skipif(
+    not hasattr(pexpect, "spawn"), reason="pexpect does not have spawn"
 )
 
 
@@ -386,7 +390,7 @@ def test_marker_help(testdir):
 
 
 @pytest.mark.parametrize(
-    "debugging_module,debugging_set_trace",
+    ["debugging_module", "debugging_set_trace"],
     [
         ("pdb", "set_trace()"),
         pytest.param(
@@ -404,6 +408,7 @@ def test_marker_help(testdir):
         ),
     ],
 )
+@have_spawn
 def test_suppresses_timeout_when_debugger_is_entered(
     testdir, debugging_module, debugging_set_trace
 ):

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -408,13 +408,13 @@ def test_suppresses_timeout_when_debugger_is_entered(
     testdir, debugging_module, debugging_set_trace
 ):
     p1 = testdir.makepyfile(
-        f"""
+        """
         import pytest, {debugging_module}
 
         @pytest.mark.timeout(1)
         def test_foo():
             {debugging_module}.{debugging_set_trace}
-    """
+    """.format(debugging_module=debugging_module, debugging_set_trace=debugging_set_trace)
     )
     # todo: pydevd server @ port 4678
     child = testdir.spawn_pytest(str(p1))

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -390,8 +390,12 @@ def test_marker_help(testdir):
     [
         ("pdb", "set_trace()"),
         ("ipdb", "set_trace()"),
-        ("pydevd", "settrace(port=4678)"),
-    ],  # noqa: E231
+        pytest.param(
+            "pydevd",
+            "settrace(port=4678)",
+            marks=pytest.mark.xfail(reason="in need of way to setup pydevd server"),
+        ),
+    ],
 )
 def test_suppresses_timeout_when_debugger_is_entered(
     testdir, debugging_module, debugging_set_trace

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist = py27,py35,py36,py37,py38,pypy2,pypy3
 [testenv]
 deps = pytest
     pexpect
+    ipdb
 commands = py.test {posargs}
 
 [testenv:linting]


### PR DESCRIPTION
Fixes #32 

~~This improved functionality is implemented by checking if `pydevd.py` appears in any of the stack frames. If it does, we assume that a debugging session is active.~~ See discussion for evolution of detection.

Also updated:
 - `py.test` -> `pytest`, `py.test` is apparently deprecated
 - `README.rst` to reflect new functionality