### PR TITLE
Fix compatibility with pytest pre-releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
             tox_env: "py36"
           - v: "3.7"
             tox_env: "py37"
+          - v: "3.7"
+            tox_env: "py37"
+            pre_releases: "--pre"
           - v: "3.8"
             tox_env: "py38"
           - v: "pypy2"
@@ -35,4 +38,4 @@ jobs:
           pip install -U setuptools tox
       - name: Test
         run: |
-          tox -e ${{ matrix.python.tox_env }}
+          tox -e ${{ matrix.python.tox_env }} ${{ matrix.python.pre_releases }}

--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,7 @@ Changelog
 -----
 
 - Fix compatibility when run with pytest pre-releases.
+- Fix detection of third-party debuggers.
 
 1.4.1
 -----

--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,11 @@ might result in clearer output.
 Changelog
 =========
 
+1.4.2
+-----
+
+- Fix compatibility when run with pytest pre-releases.
+
 1.4.1
 -----
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -156,7 +156,7 @@ def pytest_enter_pdb():
     SUPPRESS_TIMEOUT = True
 
 
-def is_debugging():
+def is_debugging(trace_func=None):
     """Detect if a debugging session is in progress.
 
     This looks at both pytest's builtin pdb support as well as
@@ -168,14 +168,19 @@ def is_debugging():
      1. Examines the trace function to see if the module it originates
         from is in KNOWN_DEBUGGING_MODULES.
      2. Check is SUPPRESS_TIMEOUT is set to True.
+
+    :param trace_func: the current trace function, if not given will use
+        sys.gettrace(). Used to unit-test this function.
     """
     global SUPPRESS_TIMEOUT, KNOWN_DEBUGGING_MODULES
     if SUPPRESS_TIMEOUT:
         return True
-    trace_func = sys.gettrace()
+    if trace_func is None:
+        trace_func = sys.gettrace()
     if trace_func and inspect.getmodule(trace_func):
+        parts = inspect.getmodule(trace_func).__name__.split(".")
         for name in KNOWN_DEBUGGING_MODULES:
-            if name in inspect.getmodule(trace_func):
+            if name in parts:
                 return True
     return False
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -13,7 +13,7 @@ import sys
 import threading
 import traceback
 from collections import namedtuple
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 import py
 import pytest
@@ -381,8 +381,8 @@ def timeout_timer(item, timeout):
     try:
         capman = item.config.pluginmanager.getplugin("capturemanager")
         if capman:
-            pytest_version = StrictVersion(pytest.__version__)
-            if pytest_version >= StrictVersion("3.7.3"):
+            pytest_version = LooseVersion(pytest.__version__)
+            if pytest_version >= LooseVersion("3.7.3"):
                 capman.suspend_global_capture(item)
                 stdout, stderr = capman.read_global_capture()
             else:

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -462,3 +462,24 @@ def test_suppresses_timeout_when_debugger_is_entered(
         child.terminate(force=True)
     assert "timeout >0.01s" not in result
     assert "fail" not in result
+
+
+def test_is_debugging(monkeypatch):
+    import pytest_timeout
+
+    assert not pytest_timeout.is_debugging()
+
+    # create a fake module named "custom.pydevd" with a trace function on it
+    from types import ModuleType
+
+    module_name = "custom.pydevd"
+    module = ModuleType(module_name)
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    def custom_trace(*args):
+        pass
+
+    custom_trace.__module__ = module_name
+    module.custom_trace = custom_trace
+
+    assert pytest_timeout.is_debugging(custom_trace)


### PR DESCRIPTION
* Added a pre-release run to CI: this helps testing pytest-timeout with pytest prereleases from now on.
* Fix compatibility with pytest prereleases: the problem was that StrictVersion from distutils doesn't recognize a release candidate (such as 6.0.0rc1) as a valid version, although it is supported by [PEP-0440](https://www.python.org/dev/peps/pep-0440/#pre-releases).
* Fix `is_debugging` function: it was using `name in <module object>` which is a TypeError. It was working previously with the builtin pdb because of the pytest_enter_pdb hook which is triggered by pytest.

Fix #68