### PR TITLE
Skip test_cov if pytest-cov is not installed

### DIFF
--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -77,6 +77,7 @@ def test_thread(testdir):
 )
 def test_cov(testdir):
     # This test requires pytest-cov
+    pytest.importorskip("pytest_cov")
     testdir.makepyfile(
         """
         import time


### PR DESCRIPTION
Skip test_cov gracefully if pytest_cov module can't be imported.
This would help us since we're removing py2 support from pytest-cov
but still need it for pytest-timeout.