### PR TITLE
Annotate test failures in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps = pytest
     pexpect
     ipdb
     pytest-cov
+    pytest-github-actions-annotate-failures
 commands = pytest {posargs}
 
 [testenv:linting]


### PR DESCRIPTION
You get a much nicer UX when a test fails. It can't hurt to use this.