### PR TITLE
switch to thread timeout method when not on main-thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ docs/_build/
 
 # IDE
 .idea
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -218,6 +218,12 @@ session using ```--pdb``` or similar.
 Changelog
 =========
 
+2.0.0
+-----
+
+- Use thread timeout method when plugin is not called from main
+  thread to avoid crash.
+
 1.4.2
 -----
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -193,7 +193,15 @@ def timeout_setup(item):
     params = get_params(item)
     if params.timeout is None or params.timeout <= 0:
         return
-    if params.method == "signal":
+
+    timeout_method = params.method
+    if (
+        timeout_method == "signal"
+        and threading.current_thread() is not threading.main_thread()
+    ):
+        timeout_method = "thread"
+
+    if timeout_method == "signal":
 
         def handler(signum, frame):
             __tracebackhide__ = True
@@ -206,7 +214,7 @@ def timeout_setup(item):
         item.cancel_timeout = cancel
         signal.signal(signal.SIGALRM, handler)
         signal.setitimer(signal.ITIMER_REAL, params.timeout)
-    elif params.method == "thread":
+    elif timeout_method == "thread":
         timer = threading.Timer(params.timeout, timeout_timer, (item, params.timeout))
         timer.name = "%s %s" % (__name__, item.nodeid)
 


### PR DESCRIPTION
This method times-out the thread on windows without crashing the test worker.