### PR TITLE
Add `method = both`: 1. signal + 2. thread

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,19 @@ interfere with the code under test.  If the code under test uses
 SIGALRM itself things will go wrong and you will have to choose the
 *thread* method.
 
+both
+----
+
+This method attempts to combine the reliability of the *thread* method
+with the gracefulness of the *signal* method. After ``timeout`` seconds
+a signal-based attempt to interrupt the program is started. If the
+signal handler is not executed, the harsh *thread* method kills the
+thread after additional ``kill_delay`` seconds.
+If your code uses a custom signal handler, it will interfere and break
+the soft *signal* attempt, so you might want to switch to *thread*.
+Similar to ``PYTEST_TIMEOUT``, you can specify the kill delay with the
+``PYTEST_KILL_DELAY`` environment variable.
+
 Specifying the Timeout Method
 -----------------------------
 


### PR DESCRIPTION
**STATUS:** rather drafty, feedback welcome. Will be modified soon.

The new method aims at combining the advantages of `method = thread` (reliability) and `method = signal` (gracefulness, ability to continue).
A new option `kill_delay` is added to configure how much time the test is granted to handle the timeout thrown by the signalling method. After that time has expired, the `thread` method is used.
Two new tests ensure that the new method works as expected, existing tests have been parameterized to include the new method.
The README now contains a small section documenting the method and its `kill_delay` configuration option.

Partially related (motivated by): #87.
Also related (it seems??): #88.