### PR TITLE
Increase pytest requirment to >=5.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,6 +218,11 @@ session using ```--pdb``` or similar.
 Changelog
 =========
 
+2.1.0
+-----
+
+- Increase pytest requirement to >=5.0.0.  Thanks Dominic Davis-Foster.
+
 2.0.0
 -----
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -13,7 +13,6 @@ import sys
 import threading
 import traceback
 from collections import namedtuple
-from distutils.version import LooseVersion
 
 import py
 import pytest
@@ -394,12 +393,8 @@ def timeout_timer(item, timeout):
     try:
         capman = item.config.pluginmanager.getplugin("capturemanager")
         if capman:
-            pytest_version = LooseVersion(pytest.__version__)
-            if pytest_version >= LooseVersion("3.7.3"):
-                capman.suspend_global_capture(item)
-                stdout, stderr = capman.read_global_capture()
-            else:
-                stdout, stderr = capman.suspend_global_capture(item)
+            capman.suspend_global_capture(item)
+            stdout, stderr = capman.read_global_capture()
         else:
             stdout, stderr = None, None
         write_title("Timeout", sep="+")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license="MIT",
     py_modules=["pytest_timeout"],
     entry_points={"pytest11": ["timeout = pytest_timeout"]},
-    install_requires=["pytest>=3.6.0"],
+    install_requires=["pytest>=5.0.0"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",


### PR DESCRIPTION
Fixes #91

I tried to test with pytest 4.x, but the tests fail because of an API change in attrs (which pytest depends on). 
I've instead opted for 5.0.0 (released June 2019) as the lower bound.