### PR TITLE
Fixed PyCharm debugger timeouts

### DIFF
--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -40,7 +40,7 @@ used in the test.
 
 # bdb covers pdb, ipdb, and possibly others
 # pydevd covers PyCharm, VSCode, and possibly others
-KNOWN_DEBUGGING_MODULES = {"pydevd", "bdb"}
+KNOWN_DEBUGGING_MODULES = {"pydevd", "bdb", "pydevd_frame_evaluator"}
 Settings = namedtuple("Settings", ["timeout", "method", "func_only"])
 
 


### PR DESCRIPTION
Fixes #78 

It seems like PyCharm changed the module they use (or at least the name).