### PR TITLE
fix: add setuptools python_requires check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     py_modules=["pytest_timeout"],
     entry_points={"pytest11": ["timeout = pytest_timeout"]},
     install_requires=["pytest>=5.0.0"],
+    python_requires='>=3.6',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     py_modules=["pytest_timeout"],
     entry_points={"pytest11": ["timeout = pytest_timeout"]},
     install_requires=["pytest>=5.0.0"],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",


### PR DESCRIPTION
Note: supporting python_requires requires setuptools>=24.2.0 and pip>=9.0.0 to benefit from it.
Details here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

Will prevent users with Python 2.7 or 3.5 from downloading a sdist version they cannot build.

I see two problems: 

- seems like you dropped the Python 2 support by adding https://github.com/pytest-dev/pytest-timeout/blob/master/setup.py#L4. If you will try to build this on python 2 you will get this error: `'encoding' is an invalid keyword argument for this function`
- The pytest version has been upgraded to the latest from what I can see in the setup.py https://github.com/pytest-dev/pytest-timeout/blob/master/setup.py#L19 and starting from the 5.0.0 version, pytest dropped the Python 2 support. 

From my point of view, both cases will be fixed by adding `python_requires>=3.6` the same as pytest: https://github.com/pytest-dev/pytest/blob/main/setup.cfg#L54 

(I'm not sure if the changelog should be updated in the same PR, if yes I will do it in another commit)
