### PR TITLE
add python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     py_modules=["pytest_timeout"],
     entry_points={"pytest11": ["timeout = pytest_timeout"]},
     install_requires=["pytest>=5.0.0"],
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",


### PR DESCRIPTION
Noticed `python_requires` is missing after `pytest-timeout` started failing when it was being inexplicably installed on unsupported Python versions.

Unfortunately `pytest-timeout<=2.0.0` is irreparably broken but at least future versions won't try to install on unsupported Python versions
