### PR TITLE
Making detection of whether a debugger is attached more flexible

### DIFF
--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -179,7 +179,7 @@ def is_debugging(trace_func=None):
     if trace_func and inspect.getmodule(trace_func):
         parts = inspect.getmodule(trace_func).__name__.split(".")
         for name in KNOWN_DEBUGGING_MODULES:
-            if name in parts:
+            if any(part.startswith(name) for part in parts):
                 return True
     return False
 


### PR DESCRIPTION
Previously, the debugger was only recognized if the name was matching exactly one of the well-known debugger names, which was not working as expected on MacOS. With these changes, a debugger that is called `pydevd_frame_evalaluator_darwin_39_64` would also be recognized by the prefix `pydevd_frame_evaluator`, thus disabling timeouts.

See: #109 