### PR TITLE
Add custom hooks specifications for overriding setup_timeout and teardown_timeout methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -255,15 +255,36 @@ regarding to use custom hooks.
 ----------------------------
 
     @pytest.hookspec(firstresult=True)
-    def pytest_timeout_set_timer(item):
+    def pytest_timeout_set_timer(item, settings):
         """Called at timeout setup.
 
         'item' is a pytest node to setup timeout for.
+
+        'settings' is Settings namedtuple (described below).
 
         Can be overridden by plugins for alternative timeout implementation strategies.
 
         """
 
+
+``Settings``
+------------
+
+When ``pytest_timeout_set_timer`` is called, ``settings`` argument is passed.
+
+The argument has ``Settings`` namedtuple type with the following fields:
+
++-----------+-------+--------------------------------------------------------+
+|Attribute  | Index | Value                                                  |
++===========+=======+========================================================+
+| timeout   | 0     | timeout in seconds or ``None`` for no timeout          |
++-----------+-------+--------------------------------------------------------+
+| method    | 1     | Method mechanism,                                      |
+|           |       | ``'signal'`` and ``'thread'`` are supported by default |
++-----------+-------+--------------------------------------------------------+
+| func_only | 2     | Apply timeout to test function only if ``True``,       |
+|           |       |  wrap all test function and its fixtures otherwise     |
++-----------+-------+--------------------------------------------------------+
 
 ``pytest_timeout_cancel_timer``
 -------------------------------
@@ -279,6 +300,20 @@ regarding to use custom hooks.
 
         """
 
+``is_debugging``
+----------------
+
+The the timeout occurs, user can open the debugger session. In this case, the timeout
+should be discarded.  A custom hook can check this case by calling ``is_debugging()``
+function::
+
+    import pytest
+    import pytest_timeout
+
+    def on_timeout():
+        if pytest_timeout.is_debugging():
+            return
+        pytest.fail("+++ Timeout +++")
 
 
 Changelog

--- a/README.rst
+++ b/README.rst
@@ -303,7 +303,7 @@ The argument has ``Settings`` namedtuple type with the following fields:
 ``is_debugging``
 ----------------
 
-The the timeout occurs, user can open the debugger session. In this case, the timeout
+When the timeout occurs, user can open the debugger session. In this case, the timeout
 should be discarded.  A custom hook can check this case by calling ``is_debugging()``
 function::
 

--- a/README.rst
+++ b/README.rst
@@ -240,7 +240,7 @@ session using ``--pdb`` or similar.
 Extending pytest-timeout with plugings
 ======================================
 
-``pytest-timeout`` provides two hooks that can be used for extending the tool.  There
+``pytest-timeout`` provides two hooks that can be used for extending the tool.  These
 hooks are used for for setting the timeout timer and cancelling it it the timeout is not
 reached.
 

--- a/README.rst
+++ b/README.rst
@@ -324,6 +324,8 @@ Unreleased
 
 - Get terminal width from shlib instead of deprecated py, thanks
   Andrew Svetlov.
+- Add an API for extending ``pytest-timeout`` functionality
+  with third-party plugins, thanks Andrew Svetlov.
 
 2.0.2
 -----

--- a/README.rst
+++ b/README.rst
@@ -237,6 +237,50 @@ debugging frameworks modules OR if pytest itself drops you into a pdb
 session using ``--pdb`` or similar.
 
 
+Extending pytest-timeout with plugings
+======================================
+
+``pytest-timeout`` provides two hooks that can be used for extending the tool.  There
+hooks are used for for setting the timeout timer and cancelling it it the timeout is not
+reached.
+
+For example, ``pytest-asyncio`` can provide asyncio-specific code that generates better
+traceback and points on timed out ``await`` instead of the running loop ieration.
+
+See `pytest hooks documentation
+<https://docs.pytest.org/en/latest/how-to/writing_hook_functions.html>`_ for more info
+regarding to use custom hooks.
+
+``pytest_timeout_set_timer``
+----------------------------
+
+    @pytest.hookspec(firstresult=True)
+    def pytest_timeout_set_timer(item):
+        """Called at timeout setup.
+
+        'item' is a pytest node to setup timeout for.
+
+        Can be overridden by plugins for alternative timeout implementation strategies.
+
+        """
+
+
+``pytest_timeout_cancel_timer``
+-------------------------------
+
+
+    @pytest.hookspec(firstresult=True)
+    def pytest_timeout_cancel_timer(item):
+        """Called at timeout teardown.
+
+        'item' is a pytest node which was used for timeout setup.
+
+        Can be overridden by plugins for alternative timeout implementation strategies.
+
+        """
+
+
+
 Changelog
 =========
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -71,6 +71,8 @@ def pytest_addoption(parser):
 
 
 class TimeoutHooks:
+    """Timeout specific hooks"""
+
     @pytest.hookspec(firstresult=True)
     def pytest_timeout_setup(item):
         """Called at timeout setup.
@@ -93,6 +95,7 @@ class TimeoutHooks:
 
 
 def pytest_addhooks(pluginmanager):
+    """Register timeout-specific hooks"""
     pluginmanager.add_hookspecs(TimeoutHooks)
 
 

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -71,7 +71,7 @@ def pytest_addoption(parser):
 
 
 class TimeoutHooks:
-    """Timeout specific hooks"""
+    """Timeout specific hooks."""
 
     @pytest.hookspec(firstresult=True)
     def pytest_timeout_setup(item):
@@ -95,7 +95,7 @@ class TimeoutHooks:
 
 
 def pytest_addhooks(pluginmanager):
-    """Register timeout-specific hooks"""
+    """Register timeout-specific hooks."""
     pluginmanager.add_hookspecs(TimeoutHooks)
 
 

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -508,27 +508,21 @@ def test_not_main_thread(testdir):
     )
 
 
-def test_plugin_is_debugging(request):
-    config = request.config
-    plugin = config.pluginmanager.get_plugin("timeout")
-    assert not plugin.is_debugging()
-
-
 def test_plugin_interface(testdir):
     testdir.makeconftest(
         """
      import pytest
 
      @pytest.mark.tryfirst
-     def pytest_timeout_setup(item):
+     def pytest_timeout_set_timer(item):
          print()
-         print("pytest_timeout_setup")
+         print("pytest_timeout_set_timer")
          return True
 
      @pytest.mark.tryfirst
-     def pytest_timeout_teardown(item):
+     def pytest_timeout_cancel_timer(item):
          print()
-         print("pytest_timeout_teardown")
+         print("pytest_timeout_cancel_timer")
          return True
     """
     )
@@ -542,4 +536,9 @@ def test_plugin_interface(testdir):
     """
     )
     result = testdir.runpytest("-s")
-    result.stdout.fnmatch_lines(["pytest_timeout_setup", "pytest_timeout_teardown"])
+    result.stdout.fnmatch_lines(
+        [
+            "pytest_timeout_set_timer",
+            "pytest_timeout_cancel_timer",
+        ]
+    )

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -514,7 +514,7 @@ def test_plugin_interface(testdir):
      import pytest
 
      @pytest.mark.tryfirst
-     def pytest_timeout_set_timer(item):
+     def pytest_timeout_set_timer(item, settings):
          print()
          print("pytest_timeout_set_timer")
          return True


### PR DESCRIPTION
Using bare `pytest-timeout` with `pytest-asyncio` works but timeout's traceback is not perfect.
It points at `selector.select()` call (`epoll.poll()` for linux case for example) instead of timed out `await f(...)` call.

`pytest-asyncio` has a pull request for providing better timeout support https://github.com/pytest-dev/pytest-asyncio/pull/216 which generates awesome tracebacks but doesn't work well with a debugger.

I don't want to copy-paste all hard work that is done by `pytest-timeout` already but propose two hooks instead: `pytest_timeout_setup(item)` and `pytest_timeout_teardown(item)`, both are marked as `tryfirst=True`.

Having these hooks, `pytest-asyncio` can provide its own implementation (which should use `pluginmanager.get_plugin('timeout').is_debugging()`, sure) to override default timeout methods but keep all other functionality untouched.

The pull request deliberately adds the minimum required changes only. 
In the future, I can imagine a pluggable `timeout_method` choice set but it is not required for the bare minimum.