### PR TITLE
Func Only Respects Environment Default

### DIFF
--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -384,7 +384,7 @@ def _validate_method(method, where):
 
 def _validate_func_only(func_only, where):
     if func_only is None:
-        return False
+        return None
     if not isinstance(func_only, bool):
         raise ValueError("Invalid func_only value %s from %s" % (func_only, where))
     return func_only

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -378,7 +378,7 @@ def test_ini_timeout_func_only_marker_override(testdir):
         @pytest.fixture
         def slow():
             time.sleep(2)
-        @pytest.mark.timeout(1.5) 
+        @pytest.mark.timeout(1.5)
         def test_foo(slow):
             pass
     """


### PR DESCRIPTION
A simple change to ensure that if func_only is not specified on a timeout marker, it can utilize the environment default. Presently when this function is called as part of `_get_item_settings` it returns False, so it never enters the following check to utilize the environment default:
```
if func_only is None:
        func_only = item.config._env_timeout_func_only
```
This change should not impact the usage in `get_env_settings` since that function converts it to a boolean via `return Settings(timeout, method, func_only or False)`.

The motivation is that we were seeing tests fail in fixtures due to timeouts when the default in pytest.ini was set to `timeout_func_only = true`. The only present workaround is to explicitly specify the func_only argument to every instance of a timeout marker on individual tests.

I validated this change on the branch by running the following check before/after:

pytest.ini
```
timeout_method = signal
timeout = 5
timeout_func_only = true
```

test
```
import pytest
import time

class TestClass:
    @pytest.fixture(autouse=False, scope='function')
    def wait_a_bit(self):
        time.sleep(10.0)
        yield
    
    def test_pytest_timeout_func_only_no_marker(self, wait_a_bit):
        assert True
    
    @pytest.mark.timeout(3.0)
    def test_pytest_timeout_func_only_explicit_marker(self, wait_a_bit):
        assert True
```

The first test passes against both master and branch because it doesn't try to parse the marker. The second test fails against master and passes against this branch. Let me know if there's any other tests I should run.