### PR TITLE
Add py to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license="MIT",
     py_modules=["pytest_timeout"],
     entry_points={"pytest11": ["timeout = pytest_timeout"]},
-    install_requires=["pytest>=5.0.0"],
+    install_requires=["pytest>=5.0.0", "py>=1.8.2"],
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
After this commit https://github.com/pytest-dev/pytest/commit/19dda7c9bdc8ef71c792e0f77a9595bfad8d9248 (> 7.2) `py` is no longer installed by `pytest`.

Like other pytest plugins, https://github.com/pytest-dev/pytest/issues/10420 , `py` needs to be installed directly post 7.2.