### PR TITLE
docs: add a warning about using `timeout_func_only = true` in INI alongside with `pytest.mark` on a test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,9 +227,10 @@ this really isn't an option a ``timeout_func_only`` boolean setting
 exists which can be set in the pytest ini configuration file, as
 documented in ``pytest --help``.
 
-A decorator will override ``timeout_func_only = true`` in the pytest ini
-file to the default value. If you need to keep this option for a
-decorated test, you must specify the option explicitly again:
+For the decorated function, a decorator will override
+``timeout_func_only = true`` in the pytest ini file to the default
+value. If you need to keep this option for a decorated test, you
+must specify the option explicitly again:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -229,7 +229,7 @@ documented in ``pytest --help``.
 
 A decorator will override ``timeout_func_only = true`` in the pytest ini
 file to the default value. If you need to keep this option for a
-decorated test, you must specify the option again explicitly:
+decorated test, you must specify the option explicitly again:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,16 @@ this really isn't an option a ``timeout_func_only`` boolean setting
 exists which can be set in the pytest ini configuration file, as
 documented in ``pytest --help``.
 
+A decorator will override ``timeout_func_only = true`` in the pytest ini
+file to the default value. If you need to keep this option for a
+decorated test, you must specify the option again explicitly:
+
+.. code:: python
+
+   @pytest.mark.timeout(60, func_only=True)
+   def test_foo():
+       pass
+
 
 Debugger Detection
 ==================


### PR DESCRIPTION
Related to https://github.com/pytest-dev/pytest-timeout/issues/142#issuecomment-1753528786