### PR TITLE
Update README.rst with pytest-xdist 3.0.2 news

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,10 +137,10 @@ The downsides of this method are that there is a relatively large
 overhead for running each test and that test runs are not completed.
 This means that other pytest features, like e.g. JUnit XML output or
 fixture teardown, will not function normally.  The second issue might
-be alleviated by using the ``--boxed`` option of the pytest-xdist_
+be alleviated by using the ``--forked`` option of the pytest-forked_
 plugin.
 
-.. _pytest-xdist: https://pypi.org/project/pytest-xdist/
+.. _pytest-forked: https://pypi.org/project/pytest-forked/
 
 The benefit of this method is that it will always work.  Furthermore
 it will still provide you debugging information by printing the stacks


### PR DESCRIPTION
In `pytest-xdist 3.0`, the option `--boxed` was removed in favor of the `pytest-forked` plugin.

This PR adjusts the advice in the README file to the new (well... Dec 2021) situation.