### PR TITLE
Change error message to clearly relate it to pytest-timeout

### DIFF
--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -495,7 +495,7 @@ def timeout_sigalrm(item, settings):
     dump_stacks(terminal)
     if nthreads > 1:
         terminal.sep("+", title="Timeout")
-    pytest.fail("Timeout >%ss" % settings.timeout)
+    pytest.fail("Timeout (>%ss) from pytest-timeout plugin." % settings.timeout)
 
 
 def timeout_timer(item, settings):

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -21,7 +21,7 @@ import pytest
 __all__ = ("is_debugging", "Settings")
 SESSION_TIMEOUT_KEY = pytest.StashKey[float]()
 SESSION_EXPIRE_KEY = pytest.StashKey[float]()
-
+PYTEST_FAILURE_MESSAGE = "Timeout (>%ss) from pytest-timeout."
 
 HAVE_SIGALRM = hasattr(signal, "SIGALRM")
 if HAVE_SIGALRM:
@@ -495,7 +495,7 @@ def timeout_sigalrm(item, settings):
     dump_stacks(terminal)
     if nthreads > 1:
         terminal.sep("+", title="Timeout")
-    pytest.fail("Timeout (>%ss) from pytest-timeout plugin." % settings.timeout)
+    pytest.fail(PYTEST_FAILURE_MESSAGE % settings.timeout)
 
 
 def timeout_timer(item, settings):

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -5,7 +5,10 @@ import time
 
 import pexpect
 import pytest
+from pytest_timeout import PYTEST_FAILURE_MESSAGE
 
+
+MATCH_FAILURE_MESSAGE = f"*Failed: {PYTEST_FAILURE_MESSAGE}*"
 pytest_plugins = "pytester"
 
 have_sigalrm = pytest.mark.skipif(
@@ -44,7 +47,7 @@ def test_sigalrm(pytester):
      """
     )
     result = pytester.runpytest_subprocess("--timeout=1")
-    result.stdout.fnmatch_lines(["*Failed: Timeout (>1.0s) from pytest-timeout plugin.*"])
+    result.stdout.fnmatch_lines([MATCH_FAILURE_MESSAGE % "1.0"])
 
 
 def test_thread(pytester):
@@ -239,7 +242,7 @@ def test_timeout_mark_sigalrm(pytester):
     """
     )
     result = pytester.runpytest_subprocess()
-    result.stdout.fnmatch_lines(["*Failed: Timeout (>1.0s) from pytest-timeout plugin.*"])
+    result.stdout.fnmatch_lines([MATCH_FAILURE_MESSAGE % "1.0"])
 
 
 def test_timeout_mark_timer(pytester):

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -44,7 +44,7 @@ def test_sigalrm(pytester):
      """
     )
     result = pytester.runpytest_subprocess("--timeout=1")
-    result.stdout.fnmatch_lines(["*Failed: Timeout >1.0s*"])
+    result.stdout.fnmatch_lines(["*Failed: Timeout (>1.0s) from pytest-timeout plugin.*"])
 
 
 def test_thread(pytester):
@@ -239,7 +239,7 @@ def test_timeout_mark_sigalrm(pytester):
     """
     )
     result = pytester.runpytest_subprocess()
-    result.stdout.fnmatch_lines(["*Failed: Timeout >1.0s*"])
+    result.stdout.fnmatch_lines(["*Failed: Timeout (>1.0s) from pytest-timeout plugin.*"])
 
 
 def test_timeout_mark_timer(pytester):
@@ -480,7 +480,7 @@ def test_suppresses_timeout_when_debugger_is_entered(
     result = child.read().decode().lower()
     if child.isalive():
         child.terminate(force=True)
-    assert "timeout >1.0s" not in result
+    assert "timeout (>1.0s)" not in result
     assert "fail" not in result
 
 
@@ -524,7 +524,7 @@ def test_disable_debugger_detection_flag(
     result = child.read().decode().lower()
     if child.isalive():
         child.terminate(force=True)
-    assert "timeout >1.0s" in result
+    assert "timeout (>1.0s)" in result
     assert "fail" in result
 
 


### PR DESCRIPTION
Is should have less than 60 chars for most timeout values and is more direct than the one I proposed in the issue.

Closes #179 