### PR TITLE
update README to list breaking change on 2.3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -413,6 +413,7 @@ x.y.z
   directly to ``sys.{stdout,stderr}``.
   This change also switches all output from ``sys.stderr`` to ``sys.stdout``.
   Thanks Pedro Algarvio.
+- *Breaking change*, remove `write_title` and API change of `dump_stack`.
 - Pytest 7.0.0 is now the minimum supported version.  Thanks Pedro Algarvio.
 - Add ``--session-timeout`` option and ``session_timeout`` setting.
   Thanks Brian Okken.


### PR DESCRIPTION
Version 2.3.0 removes `write_title` and changes `dump_stacks`. The change is related to the introduction of Terminal, that is listed in the README, but is not stated the API change.