### PR TITLE
add ruff and typos linters, drop black/isort/flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,12 @@
 ---
 repos:
-  - repo: https://github.com/psf/black
-    rev: 25.11.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.10
     hooks:
-      - id: black
-        args: [--safe, --quiet, --target-version, py310]
-  - repo: https://github.com/asottile/blacken-docs
-    rev: 1.20.0
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black==25.11.0]
+      - id: ruff-format
+      - id: ruff-check
+        args: [--fix]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -33,26 +30,18 @@ repos:
         args:
           - --pytest-test-first
         language_version: python3
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        language_version: python3
-        additional_dependencies: [flake8-typing-imports==1.17.0]
-  - repo: https://github.com/pycqa/isort
-    rev: 7.0.0
-    hooks:
-      - id: isort
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.1
-    hooks:
-      - id: pyupgrade
-        args: [--keep-percent-format, --py310-plus]
+
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
       - id: rst-backticks
+
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.37.1
     hooks:
       - id: yamllint
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.40.0
+    hooks:
+      - id: typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,6 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.40.0
+    rev: v1.42.0
     hooks:
       - id: typos

--- a/README.rst
+++ b/README.rst
@@ -394,6 +394,7 @@ Changelog
 
 x.y.z
 -----
+- Add ruff and typos linters, drop black/isort/flake8 linters. Thanks Vladimir Roshchin.
 - Minimum support Python3.10 and pytest=8.0. Thanks Vladimir Roshchin.
 - Add support Python3.13 and Python3.14. Thanks Vladimir Roshchin.
 - Detect debuggers registered with sys.monitoring. Thanks Rich Chiodo.

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -227,7 +227,7 @@ def pytest_report_header(config):
 
     session_timeout = config.getoption("session_timeout")
     if session_timeout:
-        timeout_header.append("session timeout: %ss" % session_timeout)
+        timeout_header.append(f"session timeout: {session_timeout}s")
     if timeout_header:
         return timeout_header
     return None
@@ -413,7 +413,7 @@ def _parse_marker(marker):
     """
     if not marker.args and not marker.kwargs:
         raise TypeError("Timeout marker must have at least one argument")
-    timeout = method = func_only = NOTSET = object()
+    timeout = method = func_only = NOTSET = object()  # noqa: N806
     for kw, val in marker.kwargs.items():
         if kw == "timeout":
             timeout = val
@@ -448,9 +448,8 @@ def _validate_timeout(timeout, where):
         return None
     try:
         return float(timeout)
-    except ValueError:
-        msg = f"Invalid timeout {timeout} from {where}"
-        raise ValueError(msg)
+    except ValueError as err:
+        raise ValueError(f"Invalid timeout {timeout} from {where}") from err
 
 
 def _validate_method(method, where):
@@ -476,8 +475,8 @@ def _validate_disable_debugger_detection(disable_debugger_detection, where):
         return None
     if not isinstance(disable_debugger_detection, bool):
         raise ValueError(
-            "Invalid disable_debugger_detection value %s from %s"
-            % (disable_debugger_detection, where)
+            f"Invalid disable_debugger_detection value {disable_debugger_detection}"
+            f" from {where}"
         )
     return disable_debugger_detection
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,76 @@
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "migrations",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+line-length = 88 # like black
+target-version = "py310"
+fix = true
+unsafe-fixes = true
+
+
+[lint]
+select = [
+    "E",        # pycodestyle
+    "F",        # pyflakes
+    "I",        # isort
+    "N",        # pep8-naming
+    "UP",       # pyupgrade
+    "B",        # bugbear
+    "C4",       # comprehensions
+    "SIM",      # simplify
+    "TID",      # tidy imports
+    "G",        # f-string is forbidden
+    "T",        # print is forbidden
+    "FURB",     # Refurb
+    "ASYNC",    # flake8-async
+    "PERF",     # Perflint
+    "PLE",      # pylint (error)
+    "T10",      # flake8-debugger
+    "EXE",      # flake8-executable
+    "INT",      # flake8-gettext
+    "ISC",      # flake8-implicit-str-concat
+    "PT",       # pytest
+    "LOG",      # logging
+    "S",        # bandit
+]
+ignore = [
+    "S311",     # Random
+]
+[lint.per-file-ignores]
+"*test_*" = ["S101"] # asserts in tests
+
+[lint.isort]
+combine-as-imports = true
+force-wrap-aliases = true
+split-on-trailing-comma = true
+
+[format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -440,7 +440,7 @@ def test_marker_help(pytester):
 
 
 @pytest.mark.parametrize(
-    ["debugging_module", "debugging_set_trace"],
+    ("debugging_module", "debugging_set_trace"),
     [
         ("pdb", "set_trace()"),
         pytest.param(
@@ -484,7 +484,7 @@ def test_suppresses_timeout_when_debugger_is_entered(
 
 
 @pytest.mark.parametrize(
-    ["debugging_module", "debugging_set_trace"],
+    ("debugging_module", "debugging_set_trace"),
     [
         ("pdb", "set_trace()"),
         pytest.param(

--- a/tox.ini
+++ b/tox.ini
@@ -16,10 +16,5 @@ commands = pytest {posargs}
 [testenv:linting]
 skip_install = True
 basepython = python3
-deps = pre-commit>=4.0.0
+deps = pre-commit>=4.5.1
 commands = pre-commit run --all-files --show-diff-on-failure
-
-
-[flake8]
-disable-noqa = True
-max-line-length = 88


### PR DESCRIPTION
Hello.

In this PR:
1) add https://github.com/astral-sh/ruff and https://github.com/crate-ci/typos linters.
2) drop black, isort and flake8 linters because these checks are included in ruff.