### PR TITLE
remove pytest_exception_interact hook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -394,6 +394,7 @@ Changelog
 
 x.y.z
 -----
+- Fix fixture teardowns not timing out after failed tests. Thanks Timofey Peshin.
 - Add ruff and typos linters, drop black/isort/flake8 linters. Thanks Vladimir Roshchin.
 - Minimum support Python3.10 and pytest=8.0. Thanks Vladimir Roshchin.
 - Add support Python3.13 and Python3.14. Thanks Vladimir Roshchin.

--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -233,13 +233,6 @@ def pytest_report_header(config):
     return None
 
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_exception_interact(node):
-    """Stop the timeout when pytest enters pdb in post-mortem mode."""
-    hooks = node.config.pluginmanager.hook
-    hooks.pytest_timeout_cancel_timer(item=node)
-
-
 @pytest.hookimpl
 def pytest_enter_pdb():
     """Stop the timeouts when we entered pdb.

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -176,9 +176,10 @@ def test_fix_setup_func_only(pytester):
 
 @pytest.mark.parametrize("meth", [pytest.param("signal", marks=have_sigalrm), "thread"])
 @pytest.mark.parametrize("scope", ["function", "class", "module", "session"])
-def test_fix_finalizer(meth, scope, pytester):
+@pytest.mark.parametrize("pass_test", [False, True])
+def test_fix_finalizer(meth, scope, pass_test, pytester):
     pytester.makepyfile(
-        """
+        f"""
         import time, pytest
 
         class TestFoo:
@@ -192,7 +193,7 @@ def test_fix_finalizer(meth, scope, pytester):
                 request.addfinalizer(fin)
 
             def test_foo(self, fix):
-                pass
+                assert {pass_test}
     """
     )
     result = pytester.runpytest_subprocess(


### PR DESCRIPTION
Removes the hook so that fixture teardowns can time out after a failed test. See issue #196 for details!

The `pytest_enter_pdb` hook handles debugger interactions, so I believe the original purpose of this hook is covered. I can't think of any other reason someone might find this behavior useful.