### PR TITLE
fix: read timeout_disable_debugger_detection from ini file

### DIFF
--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -82,6 +82,7 @@ def pytest_addoption(parser):
         "--timeout-disable-debugger-detection",
         dest="timeout_disable_debugger_detection",
         action="store_true",
+        default=None,
         help=DISABLE_DEBUGGER_DETECTION_DESC,
     )
     group.addoption(

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -526,6 +526,54 @@ def test_disable_debugger_detection_flag(
     assert "fail" in result
 
 
+@pytest.mark.parametrize(
+    ("debugging_module", "debugging_set_trace"),
+    [
+        ("pdb", "set_trace()"),
+        pytest.param(
+            "ipdb",
+            "set_trace()",
+            marks=pytest.mark.xfail(
+                reason="waiting on https://github.com/pytest-dev/pytest/pull/7207"
+                " to allow proper testing"
+            ),
+        ),
+        pytest.param(
+            "pydevd",
+            "settrace(port=4678)",
+            marks=pytest.mark.xfail(reason="in need of way to setup pydevd server"),
+        ),
+    ],
+)
+@have_spawn
+def test_disable_debugger_detection_ini(
+    pytester, debugging_module, debugging_set_trace
+):
+    pytester.makepyfile(
+        f"""
+        import pytest, {debugging_module}
+
+        @pytest.mark.timeout(1)
+        def test_foo():
+            {debugging_module}.{debugging_set_trace}
+    """
+    )
+    pytester.makeini(
+        """
+        [pytest]
+        timeout_disable_debugger_detection = true
+    """
+    )
+    child = pytester.spawn_pytest(str(pytester.path))
+    child.expect("test_foo")
+    time.sleep(1.2)
+    result = child.read().decode().lower()
+    if child.isalive():
+        child.terminate(force=True)
+    assert "timeout (>1.0s)" in result
+    assert "fail" in result
+
+
 def test_is_debugging(monkeypatch):
     import pytest_timeout
 


### PR DESCRIPTION
Fixes #175

The --timeout-disable-debugger-detection CLI option used store_true with a default of False, so config.getvalue() always returned False when the flag was absent and the ini file value was never checked. Setting the CLI option default to None allows the ini value to be read as a fallback, matching how timeout_method and timeout are handled.