### PR TITLE
declare timeout ini options as float

### DIFF
--- a/pytest_timeout.py
+++ b/pytest_timeout.py
@@ -93,7 +93,7 @@ def pytest_addoption(parser):
         metavar="SECONDS",
         help=SESSION_TIMEOUT_DESC,
     )
-    parser.addini("timeout", TIMEOUT_DESC)
+    parser.addini("timeout", TIMEOUT_DESC, type="float")
     parser.addini("timeout_method", METHOD_DESC)
     parser.addini("timeout_func_only", FUNC_ONLY_DESC, type="bool", default=False)
     parser.addini(
@@ -102,7 +102,7 @@ def pytest_addoption(parser):
         type="bool",
         default=False,
     )
-    parser.addini("session_timeout", SESSION_TIMEOUT_DESC)
+    parser.addini("session_timeout", SESSION_TIMEOUT_DESC, type="float")
 
 
 class TimeoutHooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
 [options]
 py_modules = pytest_timeout
 install_requires =
-    pytest>=8.0.0
+    pytest>=8.4.0
 python_requires = >=3.10
 
 [options.entry_points]

--- a/test_pytest_timeout.py
+++ b/test_pytest_timeout.py
@@ -347,6 +347,31 @@ def test_ini_timeout(pytester):
     assert result.ret
 
 
+@pytest.mark.skipif(
+    pytest.version_tuple < (9, 0),
+    reason="native [tool.pytest] table requires pytest 9",
+)
+def test_pyproject_toml_int_timeout(pytester):
+    pytester.makepyfile(
+        """
+        import time
+
+        def test_foo():
+            time.sleep(2)
+    """
+    )
+    pytester.makepyprojecttoml(
+        """
+        [tool.pytest]
+        timeout = 1
+        session_timeout = 60
+    """
+    )
+    result = pytester.runpytest_subprocess()
+    result.stdout.no_fnmatch_line("INTERNALERROR*")
+    assert result.ret
+
+
 def test_ini_timeout_func_only(pytester):
     pytester.makepyfile(
         """


### PR DESCRIPTION
Fixes #194.

With pytest 9's native `[tool.pytest]` table, `timeout = 1200` (a TOML int) makes the whole session die at configure time:

```
INTERNALERROR> TypeError: pyproject.toml: config option 'timeout' expects a string, got int: 1200
```

because `timeout` and `session_timeout` are registered with the default string ini type. Registering them with `type="float"` fixes it, matching what the values actually are. Legacy `[pytest]` ini strings like `timeout = 2.5` still parse the same way, and `timeout = 0` still means disabled (the `> 0` checks are unchanged).

One catch: `type="float"` was added to `addini` in pytest 8.4, and registering it under 8.0.x fails at plugin load, so this bumps the floor in setup.cfg to `pytest>=8.4.0`. If keeping 8.0 support matters more, the alternative is a try/except shim around the registration; happy to switch if you prefer that.

Added a regression test using `makepyprojecttoml` with int values for both options (skipped below pytest 9, where the native table doesn't exist). Suite passes locally on 3.12: 35 passed, 21 skipped (the pexpect spawn skips, this is a Windows machine).