### PR TITLE
Drop support for pypy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: Implementation :: PyPy
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 8.0
 addopts = -ra
 
 [tox]
-envlist = py310,py311,py312,py313,py314,pypy3
+envlist = py310,py311,py312,py313,py314
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Given https://github.com/numpy/numpy/issues/30416 and the (transitive)
psutil dependency no longer builds on pypy it truly is the end of an
era.
https://mastodon.social/@hynek/116194327873785309