### PR TITLE
ci: publish to PyPI on GitHub Release via Trusted Publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,12 +18,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.12
 
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U build pytest>=5.0.0
+          python -m pip install -U build
 
       - name: Build package
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.12
+          python-version: 3.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,7 @@
-name: release
+name: Release
 on:
-  push:
-    tags:
-    - '*'
+  release:
+    types: [published]
 
 jobs:
   release:
@@ -31,5 +30,4 @@ jobs:
           python -m twine check dist/*
 
       - name: Publish package distributions to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+name: release
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  release:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    if: github.repository == 'pytest-dev/pytest-timeout'
+
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U build pytest>=5.0.0
+
+      - name: Build package
+        run: |
+          python -m build
+          python -m twine check dist/*
+
+      - name: Publish package distributions to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
   release:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
-    if: github.repository == 'pytest-dev/pytest-timeout'
+    if: github.repository_owner == 'pytest-dev'
 
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,33 +1,41 @@
 name: Release
+
 on:
   release:
     types: [published]
 
 jobs:
-  release:
-    name: Upload release to PyPI
+  package:
+    name: Build and inspect package
     runs-on: ubuntu-latest
     if: github.repository_owner == 'pytest-dev'
-
     permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write  # For build provenance attestation.
+      attestations: write
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
+      - name: Build package and attest build provenance
+        uses: hynek/build-and-inspect-python-package@v3
         with:
-          python-version: 3.x
+          attest-build-provenance-github: 'true'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U build
+  publish:
+    name: Upload release to PyPI
+    needs: package
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'pytest-dev'
+    environment: release
+    permissions:
+      id-token: write  # For PyPI Trusted Publishing.
 
-      - name: Build package
-        run: |
-          python -m build
-          python -m twine check dist/*
-
+    steps:
+      - name: Download package
+        uses: actions/download-artifact@v8
+        with:
+          name: Packages
+          path: dist
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,7 @@
----
-name: build
+name: Test
 "on": [push, pull_request]
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ pytest-timeout
 .. |anaconda| image:: https://img.shields.io/conda/vn/conda-forge/pytest-timeout.svg
   :target: https://anaconda.org/conda-forge/pytest-timeout
 
-.. |ci| image:: https://github.com/pytest-dev/pytest-timeout/workflows/build/badge.svg
+.. |ci| image:: https://github.com/pytest-dev/pytest-timeout/actions/workflows/test.yml/badge.svg
   :target: https://github.com/pytest-dev/pytest-timeout/actions
 
 .. |python| image:: https://img.shields.io/pypi/pyversions/pytest-timeout.svg

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -1,0 +1,18 @@
+Releasing
+=========
+
+1. Update the version in ``setup.cfg``.
+2. Merge the PR to ``main``.
+3. Create a `GitHub Release <https://github.com/pytest-dev/pytest-timeout/releases/new>`_
+   with tag ``X.Y.Z`` targeting ``main``.
+4. The ``Release`` workflow builds the package, checks it, and publishes it
+   to PyPI.
+
+Notes for maintainers:
+
+- Publishing uses PyPI `Trusted Publishing
+  <https://docs.pypi.org/trusted-publishers/>`_ via the ``release``
+  environment: owner ``pytest-dev``, repo ``pytest-timeout``, workflow
+  ``release.yaml``, environment ``release``.
+- The ``release`` GitHub environment can require maintainer approval
+  before the publish job runs.


### PR DESCRIPTION
Replaces #154, which cannot be reopened or retargeted because its base branch `master` was deleted.

Publishes to PyPI when a GitHub Release is published, following the pytest-mock deploy pattern:

- **`package` job**: builds sdist+wheel with `hynek/build-and-inspect-python-package` (twine check + wheel-contents check included), attests GitHub build provenance. Only `id-token: write` + `attestations: write`.
- **`publish` job**: downloads the artifact and publishes via `pypa/gh-action-pypi-publish` with PyPI attestations, through the `release` environment with Trusted Publishing (no token). Only `id-token: write`.
- Both jobs guarded by `github.repository_owner == 'pytest-dev'`.
- Adds `RELEASING.rst` documenting the process.

Addresses all review feedback from #154 (split build/publish jobs, `release` environment, RELEASING.rst, owner check, `release: published` trigger, drop EOL Python pin).

Setup needed once by a maintainer: register the PyPI Trusted Publisher for `pytest-timeout` (owner `pytest-dev`, repo `pytest-timeout`, workflow `release.yaml`, environment `release`).